### PR TITLE
refactor: add back create file logic in create in file tool

### DIFF
--- a/src/extension/tools/node/createFileTool.tsx
+++ b/src/extension/tools/node/createFileTool.tsx
@@ -105,6 +105,12 @@ export class CreateFileTool implements ICopilotTool<ICreateFileParams> {
 			sendEditNotebookTelemetry(this.telemetryService, this.endpointProvider, 'createFile', uri, this._promptContext.requestId, options.model ?? this._promptContext.request?.model);
 		} else {
 			const content = removeLeadingFilepathComment(options.input.content, languageId, options.input.filePath);
+			if (!fileExists) {
+				await this.fileSystemService.writeFile(uri, Buffer.from(content));
+				doc = hasSupportedNotebooks
+					? await this.workspaceService.openNotebookDocumentAndSnapshot(uri, this.alternativeNotebookContent.getFormat(this._promptContext?.request?.model))
+					: await this.workspaceService.openTextDocumentAndSnapshot(uri);
+			}
 			await processFullRewrite(uri, doc as TextDocumentSnapshot | undefined, content, this._promptContext.stream, token, []);
 			this._promptContext.stream.textEdit(uri, true);
 			return new LanguageModelToolResult([

--- a/test/scenarios/test-agent-code-gen/agentcodegen.conversation.json
+++ b/test/scenarios/test-agent-code-gen/agentcodegen.conversation.json
@@ -12,7 +12,9 @@
             "semantic_search": true,
             "list_dir": true,
             "search_workspace_symbols": true,
-            "get_agent_code_gen_best_practices": true
+            "get_agent_code_gen_best_practices": true,
+            "create_file": true,
+
         }
     }
 ]

--- a/test/scenarios/test-agent-code-gen/tools.state.json
+++ b/test/scenarios/test-agent-code-gen/tools.state.json
@@ -1,4 +1,5 @@
 {
+    "workspaceFolderFilePath": "./",
     "activeTextEditor": {
         "selections": [
             {


### PR DESCRIPTION
Added logic in `createFileTool.tsx` to create a file if it does not already exist, write its content.
