### PR TITLE
refactor: terminal description

### DIFF
--- a/package.json
+++ b/package.json
@@ -474,7 +474,7 @@
 			{
 				"name": "copilot_basicRunInTerminal",
 				"displayName": "Run in Terminal",
-				"modelDescription": "This tool allows you to execute shell commands in a persistent terminal session, preserving environment variables, working directory, and other context across multiple commands.\n\nCommand Execution:\n- Does NOT support multi-line commands\n\nDirectory Management:\n- Must use absolute paths to avoid navigation issues.\n\nProgram Execution:\n- Supports Python, Node.js, and other executables.\n- Install dependencies via pip, npm, etc.\n\nBackground Processes:\n- For long-running tasks (e.g., servers), set isBackground=true.\n- Returns a terminal ID for checking status and runtime later.\n\nOutput Management:\n- Output is automatically truncated if longer than 60KB to prevent context overflow\n- Use filters like 'head', 'tail', 'grep' to limit output size\n- For pager commands, disable paging: use 'git --no-pager' or add '| cat'\n\nBest Practices:\n- Be specific with commands to avoid excessive output\n- Use targeted queries instead of broad scans\n- Consider using 'wc -l' to count before listing many items",
+				"modelDescription": "This tool runs a command in the terminal and returns the output.",
 				"toolReferenceName": "BasicRunInTerminal",
 				"canBeReferencedInPrompt": true,
 				"tags": [],


### PR DESCRIPTION
Use a simple terminal description to replace the original VS Code terminal description. This description may be updated later.
If you encounter cases where the terminal uses cmd and causes failures, update the Windows default terminal settings. This may solve some problems.

<img width="1503" height="1127" alt="image" src="https://github.com/user-attachments/assets/6297f504-4d24-422f-a935-4c3b5dba2901" />
